### PR TITLE
Add possibility to name paths with namespace

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -11,6 +11,7 @@ parameters:
 parametersSchema:
     bladestan: structure([
         template_paths: listOf(string())
+        ?namespaced_paths: arrayOf(string())
     ])
 
 rules:

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -13,6 +13,8 @@ final class Configuration
      */
     public const TEMPLATE_PATHS = 'template_paths';
 
+    public const NAMESPACED_PATHS = 'namespaced_paths';
+
     /**
      * @param array<string, mixed> $parameters
      */
@@ -24,6 +26,10 @@ final class Configuration
         $templatePaths = $this->parameters[self::TEMPLATE_PATHS];
         Assert::isArray($templatePaths);
         Assert::allString($templatePaths);
+
+        $namespacedPaths = $this->parameters[self::NAMESPACED_PATHS] ?? [];
+        Assert::isArray($namespacedPaths);
+        Assert::allString($namespacedPaths);
     }
 
     /**
@@ -32,5 +38,13 @@ final class Configuration
     public function getTemplatePaths(): array
     {
         return $this->parameters[self::TEMPLATE_PATHS];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getNamespacedPaths(): array
+    {
+        return $this->parameters[self::NAMESPACED_PATHS] ?? [];
     }
 }

--- a/src/Laravel/View/FileViewFinderFactory.php
+++ b/src/Laravel/View/FileViewFinderFactory.php
@@ -23,11 +23,15 @@ final class FileViewFinderFactory
         // @note is the absolute path needed?
         $absoluteTemplatePaths = $this->directoryHelper->absolutizePaths($this->configuration->getTemplatePaths());
 
-        return new FileViewFinder(
+        $finder = new FileViewFinder(
             $this->filesystem,
             $absoluteTemplatePaths,
             // @note why SVG?
             ['blade.php', 'svg']
         );
+        foreach ($this->configuration->getNamespacedPaths() as $namespace => $path) {
+            $finder->addNamespace($namespace, $path);
+        }
+        return $finder;
     }
 }

--- a/src/NodeAnalyzer/TemplateFilePathResolver.php
+++ b/src/NodeAnalyzer/TemplateFilePathResolver.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TomasVotruba\Bladestan\NodeAnalyzer;
 
 use Illuminate\View\FileViewFinder;
-use Illuminate\View\ViewFinderInterface;
 use InvalidArgumentException;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
@@ -46,14 +45,6 @@ final class TemplateFilePathResolver
 
     private function normalizeName(string $name): string
     {
-        $delimiter = ViewFinderInterface::HINT_PATH_DELIMITER;
-
-        if (! str_contains($name, $delimiter)) {
-            return str_replace('/', '.', $name);
-        }
-
-        [$namespace, $name] = explode($delimiter, $name);
-
         return str_replace('/', '.', $name);
     }
 

--- a/tests/Rules/config/configured_extension.neon
+++ b/tests/Rules/config/configured_extension.neon
@@ -5,4 +5,5 @@ parameters:
     bladestan:
         template_paths:
             - tests/Rules/templates
-            - tests/Rules/templates/nested/directory
+        namespaced_paths:
+            dummyNamespace: tests/Rules/templates/nested/directory


### PR DESCRIPTION
I have a case where I need to distinguish between namespaced views. I'm using `nwidart/laravel-modules` and I have conflicting names without namespacing between these modules. Can we add those namespaces in config and parse them accordingly?
To this to work I also reverted removing the namespace from view name, maybe we could do this only on non-specified namespaced? 
If you are interested in this addition I can work on this more and get it ready for merge.