### PR TITLE
Report view errors and handle exceptions better

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -18,6 +18,11 @@ rules:
 services:
     errorFormatter.blade:
         class: Bladestan\ErrorReporting\PHPStan\ErrorFormatter\BladeTemplateErrorFormatter
+        arguments:
+            simpleRelativePathHelper: @simpleRelativePathHelper
+            showTipsOfTheDay: %tipsOfTheDay%
+            editorUrl: %editorUrl%
+            editorUrlTitle: %editorUrlTitle%
 
     - PhpParser\PrettyPrinter\Standard
     - PhpParser\ConstExprEvaluator

--- a/ecs.php
+++ b/ecs.php
@@ -2,10 +2,17 @@
 
 declare(strict_types=1);
 
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use Symplify\EasyCodingStandard\Config\ECSConfig;
 
 return ECSConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests'])
     ->withRootFiles()
+    ->withConfiguredRule(
+        GeneralPhpdocAnnotationRemoveFixer::class,
+        [
+            'annotations' => ['author', 'package', 'group', 'covers', 'category'],
+        ] // Allow @throws
+    )
     ->withPreparedSets(psr12: true, common: true, symplify: true)
     ->withSkip(['*/Fixture/*']);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 8
+    level: max
 
     paths:
         - src
@@ -9,3 +9,20 @@ parameters:
         - 'tests/*/Fixture/*'
         - 'tests/Rules/data/*'
         - 'tests/Rules/templates//*'
+
+    exceptions:
+        reportUncheckedExceptionDeadCatch: true
+        implicitThrows: false
+        check:
+            missingCheckedExceptionInThrows: true
+            tooWideThrowType: true
+        uncheckedExceptionClasses:
+            - 'Bladestan\Exception\ShouldNotHappenException'
+            - 'Nette\Utils\JsonException'
+            - 'ReflectionException'
+            - 'Webmozart\Assert\InvalidArgumentException'
+
+    ignoreErrors:
+        -
+            identifier: missingType.checkedException
+            path: tests/*

--- a/src/Compiler/FileNameAndLineNumberAddingPreCompiler.php
+++ b/src/Compiler/FileNameAndLineNumberAddingPreCompiler.php
@@ -37,7 +37,7 @@ final class FileNameAndLineNumberAddingPreCompiler
     ) {
     }
 
-    public function completeLineCommentsToBladeContents(string $fileName, string $fileContents): string
+    public function getRelativePath(string $fileName): string
     {
         foreach ($this->configuration->getTemplatePaths() as $templatePath) {
             $templatePath = rtrim($templatePath, '/') . '/';
@@ -53,6 +53,12 @@ final class FileNameAndLineNumberAddingPreCompiler
             return '';
         }
 
+        return $fileName;
+    }
+
+    public function completeLineCommentsToBladeContents(string $fileName, string $fileContents): string
+    {
+        $fileName = $this->getRelativePath($fileName);
         $lines = explode(PHP_EOL, $fileContents);
 
         $insideComponentTag = false;

--- a/src/Compiler/PhpContentExtractor.php
+++ b/src/Compiler/PhpContentExtractor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Bladestan\Compiler;
 
+use Bladestan\Exception\ShouldNotHappenException;
+
 final class PhpContentExtractor
 {
     /**
@@ -32,7 +34,11 @@ final class PhpContentExtractor
         }
 
         // Merge multiple code blocks appearing on a single line
-        $bladeCompiledContent = preg_replace('#\s*\?>.*?<\?php\s*#', ' ', $bladeCompiledContent) ?? '';
+        $bladeCompiledContent = preg_replace(
+            '#\s*\?>.*?<\?php\s*#',
+            ' ',
+            $bladeCompiledContent
+        ) ?? throw new ShouldNotHappenException('preg_replace error');
 
         preg_match_all(self::PHP_OPEN_CLOSE_TAGS_REGEX, $bladeCompiledContent, $matches, PREG_SET_ORDER);
 

--- a/src/Configuration/Configuration.php
+++ b/src/Configuration/Configuration.php
@@ -14,16 +14,24 @@ final class Configuration
     public const TEMPLATE_PATHS = 'template_paths';
 
     /**
+     * @var array{template_paths: array<string>}
+     */
+    private array $parameters = [
+        self::TEMPLATE_PATHS => [],
+    ];
+
+    /**
      * @param array<string, mixed> $parameters
      */
-    public function __construct(
-        private readonly array $parameters
-    ) {
-        Assert::keyExists($this->parameters, self::TEMPLATE_PATHS);
-
-        $templatePaths = $this->parameters[self::TEMPLATE_PATHS];
+    public function __construct(array $parameters)
+    {
+        Assert::keyExists($parameters, self::TEMPLATE_PATHS);
+        $templatePaths = $parameters[self::TEMPLATE_PATHS];
         Assert::isArray($templatePaths);
-        Assert::allString($templatePaths);
+        foreach ($templatePaths as $templatePath) {
+            Assert::true(is_string($templatePath));
+            $this->parameters[self::TEMPLATE_PATHS][] = $templatePath;
+        }
     }
 
     /**

--- a/src/ErrorReporting/Blade/TemplateErrorsFactory.php
+++ b/src/ErrorReporting/Blade/TemplateErrorsFactory.php
@@ -11,6 +11,19 @@ use PHPStan\Rules\RuleErrorBuilder;
 
 final class TemplateErrorsFactory
 {
+    public function createError(
+        string $message,
+        string $identifier,
+        int $phpFileLine,
+        string $phpFilePath,
+    ): IdentifierRuleError {
+        return RuleErrorBuilder::message($message)
+            ->file($phpFilePath)
+            ->line($phpFileLine)
+            ->identifier($identifier)
+            ->build();
+    }
+
     /**
      * @param Error[] $errors
      * @return list<IdentifierRuleError>
@@ -22,6 +35,10 @@ final class TemplateErrorsFactory
         PhpFileContentsWithLineMap $phpFileContentsWithLineMap
     ): array {
         $ruleErrors = [];
+
+        foreach ($phpFileContentsWithLineMap->errors as $error) {
+            $ruleErrors[] = $this->createError($error[0], $error[1], $phpFileLine, $phpFilePath);
+        }
 
         $phpToTemplateLines = $phpFileContentsWithLineMap->phpToTemplateLines;
 
@@ -36,7 +53,7 @@ final class TemplateErrorsFactory
 
             assert($error->getIdentifier() !== null);
 
-            $ruleError = RuleErrorBuilder::message($error->getMessage())
+            $ruleErrors[] = RuleErrorBuilder::message($error->getMessage())
                 ->file($phpFilePath)
                 ->line($phpFileLine)
                 ->metadata([
@@ -45,7 +62,6 @@ final class TemplateErrorsFactory
                 ])
                 ->identifier($error->getIdentifier())
                 ->build();
-            $ruleErrors[] = $ruleError;
         }
 
         return $ruleErrors;

--- a/src/ErrorReporting/PHPStan/ErrorFormatter/BladeTemplateErrorFormatter.php
+++ b/src/ErrorReporting/PHPStan/ErrorFormatter/BladeTemplateErrorFormatter.php
@@ -80,7 +80,7 @@ final class BladeTemplateErrorFormatter implements ErrorFormatter
                 $templateFilePath = $errorMetadata['template_file_path'] ?? null;
                 $templateLine = $errorMetadata['template_line'] ?? null;
 
-                if ($templateFilePath && $templateLine) {
+                if (is_string($templateFilePath) && is_int($templateLine)) {
                     /** @phpstan-ignore phpstanApi.method */
                     $relativeTemplateFileLine = $this->simpleRelativePathHelper->getRelativePath(
                         $templateFilePath

--- a/src/Laravel/View/BladeCompilerFactory.php
+++ b/src/Laravel/View/BladeCompilerFactory.php
@@ -6,12 +6,16 @@ namespace Bladestan\Laravel\View;
 
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\View\Compilers\BladeCompiler;
+use InvalidArgumentException;
 
 /**
  * @api factory service in config
  */
 final class BladeCompilerFactory
 {
+    /**
+     * @throws InvalidArgumentException
+     */
     public function create(): BladeCompiler
     {
         $filesystem = new Filesystem();

--- a/src/NodeAnalyzer/TemplateFilePathResolver.php
+++ b/src/NodeAnalyzer/TemplateFilePathResolver.php
@@ -19,29 +19,26 @@ final class TemplateFilePathResolver
     }
 
     /**
-     * @return string[]
+     * @throws InvalidArgumentException
      */
-    public function resolveExistingFilePaths(Expr $expr, Scope $scope): array
+    public function resolveExistingFilePath(Expr $expr, Scope $scope): ?string
     {
         $resolvedValue = $this->valueResolver->resolve($expr, $scope);
 
         if (! is_string($resolvedValue)) {
-            return [];
+            return null;
         }
 
         $resolvedValue = $this->normalizeName($resolvedValue);
 
         if (file_exists($resolvedValue)) {
-            return [$resolvedValue];
+            return $resolvedValue;
         }
 
-        $view = $this->findView($resolvedValue);
+        /** @throws InvalidArgumentException */
+        $view = $this->fileViewFinder->find($resolvedValue);
 
-        if ($view === null) {
-            return [];
-        }
-
-        return [$view];
+        return $view;
     }
 
     private function normalizeName(string $name): string
@@ -55,14 +52,5 @@ final class TemplateFilePathResolver
         [$namespace, $name] = explode($delimiter, $name);
 
         return str_replace('/', '.', $name);
-    }
-
-    private function findView(string $view): ?string
-    {
-        try {
-            return $this->fileViewFinder->find($view);
-        } catch (InvalidArgumentException) {
-            return null;
-        }
     }
 }

--- a/src/PhpParser/NodeVisitor/ViewFunctionArgumentsNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/ViewFunctionArgumentsNodeVisitor.php
@@ -16,7 +16,6 @@ use PhpParser\Node\Name;
 use PhpParser\Node\Name\FullyQualified;
 use PhpParser\Node\Stmt;
 use PhpParser\NodeVisitorAbstract;
-use Webmozart\Assert\Assert;
 
 /**
  * @api part of phpstan node visitors
@@ -91,8 +90,6 @@ final class ViewFunctionArgumentsNodeVisitor extends NodeVisitorAbstract
                 $rootViewNode->var->getArgs() !== []
             ) {
                 $cacheKey = Json::encode($rootViewNode->var);
-                Assert::string($cacheKey);
-                Assert::notEmpty($cacheKey);
 
                 //  = md5(json_encode($rootViewNode->var));
 

--- a/src/ValueObject/PhpFileContentsWithLineMap.php
+++ b/src/ValueObject/PhpFileContentsWithLineMap.php
@@ -12,7 +12,9 @@ final class PhpFileContentsWithLineMap
      */
     public function __construct(
         public readonly string $phpFileContents,
-        public readonly array $phpToTemplateLines
+        public readonly array $phpToTemplateLines,
+        /** @var list<array<int, string>> */
+        public array $errors,
     ) {
     }
 }

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -31,36 +31,30 @@ final class ViewRuleHelper
     }
 
     /**
-     * @param RenderTemplateWithParameters[] $renderTemplatesWithParameters
-     *
      * @return list<IdentifierRuleError>
      */
-    public function processNode(CallLike $callLike, Scope $scope, array $renderTemplatesWithParameters): array
-    {
-        $ruleErrors = [];
-        foreach ($renderTemplatesWithParameters as $renderTemplateWithParameter) {
-            $variablesAndTypes = $this->templateVariableTypesResolver->resolveArray(
-                $renderTemplateWithParameter->parametersArray,
-                $scope
-            );
+    public function processNode(
+        CallLike $callLike,
+        Scope $scope,
+        RenderTemplateWithParameters $renderTemplateWithParameters
+    ): array {
+        $variablesAndTypes = $this->templateVariableTypesResolver->resolveArray(
+            $renderTemplateWithParameters->parametersArray,
+            $scope
+        );
 
-            $compiledTemplate = $this->compileToPhp(
-                $renderTemplateWithParameter->templateFilePath,
-                $variablesAndTypes,
-                $scope->getFile(),
-                $callLike->getLine()
-            );
+        $compiledTemplate = $this->compileToPhp(
+            $renderTemplateWithParameters->templateFilePath,
+            $variablesAndTypes,
+            $scope->getFile(),
+            $callLike->getLine()
+        );
 
-            if (! $compiledTemplate instanceof CompiledTemplate) {
-                continue;
-            }
-
-            $currentRuleErrors = $this->processTemplateFilePath($compiledTemplate);
-
-            $ruleErrors = array_merge($ruleErrors, $currentRuleErrors);
+        if (! $compiledTemplate instanceof CompiledTemplate) {
+            return [];
         }
 
-        return $ruleErrors;
+        return $this->processTemplateFilePath($compiledTemplate);
     }
 
     public function setRegistry(Registry $registry): void

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -83,6 +83,16 @@ final class BladeRuleTest extends RuleTestCase
 
         yield [__DIR__ . '/Fixture/view-render-int.php', []];
 
+        yield [__DIR__ . '/Fixture/missing-template.php', [['View [missing.view] not found.', 5]]];
+
+        yield [__DIR__ . '/Fixture/missing-include.php', [['View [missing.view] not found.', 5]]];
+
+        yield [__DIR__ . '/Fixture/missing-component.php', [['View [missing.component] not found.', 5]]];
+
+        yield [__DIR__ . '/Fixture/compile-error.php', [
+            ['View [compile-error.blade.php] contains syntx errors.', 5],
+        ]];
+
         yield [__DIR__ . '/Fixture/skip-form-errors.php', []];
 
         yield [__DIR__ . '/Fixture/laravel-response-function.php', [

--- a/tests/Rules/Fixture/compile-error.php
+++ b/tests/Rules/Fixture/compile-error.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+view('compile-error');

--- a/tests/Rules/Fixture/missing-component.php
+++ b/tests/Rules/Fixture/missing-component.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+view('missing.component');

--- a/tests/Rules/Fixture/missing-include.php
+++ b/tests/Rules/Fixture/missing-include.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+view('missing-include');

--- a/tests/Rules/Fixture/missing-template.php
+++ b/tests/Rules/Fixture/missing-template.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+view('missing.view');

--- a/tests/Rules/templates/compile-error.blade.php
+++ b/tests/Rules/templates/compile-error.blade.php
@@ -1,0 +1,3 @@
+@if @if (session('success'))
+	{{ $foo }}
+@endif

--- a/tests/Rules/templates/missing-component.blade.php
+++ b/tests/Rules/templates/missing-component.blade.php
@@ -1,0 +1,1 @@
+<x-missing.component />

--- a/tests/Rules/templates/missing-include.blade.php
+++ b/tests/Rules/templates/missing-include.blade.php
@@ -1,0 +1,1 @@
+@include('missing.view', ['foo' => 'bar'])

--- a/tests/TestUtils.php
+++ b/tests/TestUtils.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Bladestan\Tests;
 
+use Illuminate\Support\Str;
 use Iterator;
-use Webmozart\Assert\Assert;
 
 final class TestUtils
 {
@@ -14,12 +14,12 @@ final class TestUtils
      */
     public static function splitFixture(string $filePath): array
     {
-        Assert::fileExists($filePath);
+        assert(file_exists($filePath));
 
         /** @var string $fileContents */
         $fileContents = file_get_contents($filePath);
 
-        $stringsCollection = str($fileContents)
+        $stringsCollection = Str::of($fileContents)
             ->split("#-----\n#")
             ->values();
 


### PR DESCRIPTION
Fixes #56

Features:
- No longer crash on missing templates (introduces `bladestan.missing`)
- No longer crashes on invalid templates (introduces `bladestan.parsing`)
- Align the custom error formatter with the latest PHPStan default formatter
- Fix all reported PHPStan issues (level 10/max)
- Better track exception flow
- Make things that should never happen in to crashes instead of being silent