### PR TITLE
Test that ->with() does not taint later calls

### DIFF
--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -111,6 +111,14 @@ final class BladeRuleTest extends RuleTestCase
             ['Undefined variable: $foo', 9],
         ]];
 
+        yield [__DIR__ . '/Fixture/with-does-not-taint.php', [
+            ['Binary operation "+" between string and 10 results in an error.', 9],
+            ['Variable $bar might not be defined.', 9],
+            ['Strict comparison using === between 1 and 1 will always evaluate to true.', 11],
+            ['Variable $foo might not be defined.', 11],
+            ['Undefined variable: $foo', 11],
+        ]];
+
         yield [__DIR__ . '/Fixture/data-from-with.php', [
             ['Binary operation "+" between string and 10 results in an error.', 9],
             ['Variable $bar might not be defined.', 9],

--- a/tests/Rules/Fixture/with-does-not-taint.php
+++ b/tests/Rules/Fixture/with-does-not-taint.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelViewFunction;
+
+use function view;
+
+view('simple_variable')->with('foo', 'bar');
+
+view('foo');


### PR DESCRIPTION
Currently if `->with('foo', 'value')` or `->withFoo('value')` is used to set data values subsequent calls to view() will think that these variables are available.

This adds a failing tests for anyone that wants to work on fixing the issue.