### PR TITLE
fix: implement methods from View implementation

### DIFF
--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -121,12 +121,13 @@ final class BladeToPHPCompiler
      */
     public function compileContent(
         string $resolvedTemplateFilePath,
+        string $viewName,
         string $fileContents,
         array $parametersArray
     ): PhpFileContentsWithLineMap {
         $this->errors = [];
 
-        $variablesAndTypes = $this->getViewData($resolvedTemplateFilePath)
+        $variablesAndTypes = $this->getViewData($viewName)
             + $parametersArray;
 
         $rawPhpContent = "<?php\n\n" . $this->inlineInclude(
@@ -178,7 +179,7 @@ final class BladeToPHPCompiler
      */
     private function getViewDataRaw(string $viewName): array
     {
-        $viewDataCollector = new ViewDataCollector($viewName);
+        $viewDataCollector = new ViewDataCollector($viewName, $this->viewFactory);
         try {
             /** @throws Throwable */
             $this->viewFactory->callComposer($viewDataCollector);

--- a/src/ValueObject/ViewDataCollector.php
+++ b/src/ValueObject/ViewDataCollector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bladestan\ValueObject;
 
+use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\Contracts\View\View;
 
 class ViewDataCollector implements View
@@ -15,12 +16,30 @@ class ViewDataCollector implements View
 
     public function __construct(
         private readonly string $viewName,
+        private readonly ViewFactory $viewFactory,
     ) {
     }
 
     public function name(): string
     {
         return $this->viewName;
+    }
+
+    /**
+     * Used by code that incorrectly assumes Illuminate\View\View
+     */
+    public function getName(): string
+    {
+        return $this->viewName;
+    }
+
+    /**
+     * Used by code that incorrectly assumes Illuminate\View\View
+     */
+    public function getPath(): string
+    {
+        return $this->viewFactory->getFinder()
+            ->find($this->viewName);
     }
 
     /**

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -107,6 +107,7 @@ final class ViewRuleHelper
 
         $phpFileContentsWithLineMap = $this->bladeToPhpCompiler->compileContent(
             $resolvedTemplateFilePath,
+            $renderTemplateWithParameters->templateName,
             $fileContents,
             $renderTemplateWithParameters->parametersArray
         );

--- a/tests/Compiler/BladeToPHPCompiler/BladeToPHPCompilerTest.php
+++ b/tests/Compiler/BladeToPHPCompiler/BladeToPHPCompilerTest.php
@@ -28,6 +28,7 @@ final class BladeToPHPCompilerTest extends PHPStanTestCase
 
         $phpFileContentsWithLineMap = $this->bladeToPHPCompiler->compileContent(
             'foo.blade.php',
+            'foo',
             $inputBladeContents,
             []
         );


### PR DESCRIPTION
This is split from https://github.com/bladestan/bladestan/pull/158 with a few adjustments to address one issue at a time.

The issue addressed here is that Telescope doesn't adhere to the View Contract and calls methods not defined there, this dimply adds these but also corrects a dependency where we where setting the path and the view name.