### PR TITLE
Respect configured rules

### DIFF
--- a/src/Rules/BladeRule.php
+++ b/src/Rules/BladeRule.php
@@ -8,7 +8,6 @@ use Bladestan\ErrorReporting\Blade\TemplateErrorsFactory;
 use Bladestan\NodeAnalyzer\BladeViewMethodsMatcher;
 use Bladestan\NodeAnalyzer\LaravelViewFunctionMatcher;
 use Bladestan\NodeAnalyzer\MailablesContentMatcher;
-use Bladestan\TemplateCompiler\Rules\TemplateRulesRegistry;
 use Bladestan\ViewRuleHelper;
 use InvalidArgumentException;
 use PhpParser\Node;
@@ -21,24 +20,18 @@ use PHPStan\Analyser\Scope;
 use PHPStan\Rules\Rule;
 
 /**
- * @implements Rule<Node>
+ * @implements Rule<CallLike>
  * @see \Bladestan\Tests\Rules\BladeRuleTest
  */
 final class BladeRule implements Rule
 {
-    /**
-     * @param list<Rule> $rules
-     * @phpstan-ignore missingType.generics
-     */
     public function __construct(
-        array $rules,
         private readonly BladeViewMethodsMatcher $bladeViewMethodsMatcher,
         private readonly LaravelViewFunctionMatcher $laravelViewFunctionMatcher,
         private readonly MailablesContentMatcher $mailablesContentMatcher,
         private readonly ViewRuleHelper $viewRuleHelper,
         private readonly TemplateErrorsFactory $templateErrorsFactory,
     ) {
-        $this->viewRuleHelper->setRegistry(new TemplateRulesRegistry($rules));
     }
 
     public function getNodeType(): string
@@ -48,8 +41,6 @@ final class BladeRule implements Rule
 
     public function processNode(Node $node, Scope $scope): array
     {
-        assert($node instanceof CallLike);
-
         $renderTemplatesWithParameters = match (true) {
             $node instanceof StaticCall,
             $node instanceof FuncCall => $this->laravelViewFunctionMatcher->match($node, $scope),

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -14,13 +14,11 @@ use Bladestan\ValueObject\CompiledTemplate;
 use InvalidArgumentException;
 use PhpParser\Node\Expr\CallLike;
 use PHPStan\Analyser\Scope;
+use PHPStan\Collectors\Registry;
 use PHPStan\Rules\IdentifierRuleError;
-use PHPStan\Rules\Registry;
 
 final class ViewRuleHelper
 {
-    private Registry $registry;
-
     public function __construct(
         private readonly FileAnalyserProvider $fileAnalyserProvider,
         private readonly TemplateErrorsFactory $templateErrorsFactory,
@@ -52,26 +50,22 @@ final class ViewRuleHelper
         return $this->processTemplateFilePath($compiledTemplate);
     }
 
-    public function setRegistry(Registry $registry): void
-    {
-        $this->registry = $registry;
-    }
-
     /**
      * @return list<IdentifierRuleError>
      */
     private function processTemplateFilePath(CompiledTemplate $compiledTemplate): array
     {
         $fileAnalyser = $this->fileAnalyserProvider->provide();
+        $templateRulesRegistry = $this->fileAnalyserProvider->getRules();
 
         /** @phpstan-ignore phpstanApi.constructor */
-        $collectorsRegistry = new \PHPStan\Collectors\Registry([]);
+        $collectorsRegistry = new Registry([]);
 
         /** @phpstan-ignore phpstanApi.method */
         $fileAnalyserResult = $fileAnalyser->analyseFile(
             $compiledTemplate->phpFilePath,
             [],
-            $this->registry,
+            $templateRulesRegistry,
             $collectorsRegistry,
             null
         );

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -6,7 +6,6 @@ namespace Bladestan\Tests\Rules;
 
 use Bladestan\Rules\BladeRule;
 use Iterator;
-use PhpParser\Node;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -242,7 +241,7 @@ final class BladeRuleTest extends RuleTestCase
     }
 
     /**
-     * @return Rule<Node>
+     * @return BladeRule
      */
     protected function getRule(): Rule
     {


### PR DESCRIPTION
Previously it would enable ALL possible rules, rather then all configured rules. This could be especially problematic if you have something like phpstan-strict installed which has a lot of options for enable individual rules.