### PR TITLE
Fix truncated component data on attribute values containing a bracket

### DIFF
--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -291,7 +291,7 @@ final class BladeToPHPCompiler
         foreach ($components as $component) {
             $class = $component[1];
             $arrayString = trim($component[2], ' ,');
-            $attributes = $this->arrayStringToArrayConverter->convert($arrayString);
+            $attributes = $this->convertComponentData($arrayString, $class);
 
             // Resolve any additional required arguments
             if (class_exists($class) && method_exists($class, '__construct')) {
@@ -336,6 +336,26 @@ final class BladeToPHPCompiler
             '',
             $rawPhpContent
         ) ?? throw new ShouldNotHappenException('preg_replace error');
+    }
+
+    /**
+     * A component's data array is located with a regular expression, so an unusual attribute value
+     * can still end the capture in the wrong place. Report that against the template and carry on
+     * with no data for this one component, rather than letting the parse error escape and abort the
+     * whole run without naming a file.
+     *
+     * @return array<string>
+     */
+    private function convertComponentData(string $arrayString, string $component): array
+    {
+        try {
+            /** @throws ParserError */
+            return $this->arrayStringToArrayConverter->convert($arrayString);
+        } catch (ParserError) {
+            $this->errors[] = ["Unable to read the data passed to component [{$component}].", 'bladestan.parsing'];
+
+            return [];
+        }
     }
 
     /**
@@ -416,7 +436,7 @@ final class BladeToPHPCompiler
             }
 
             $includeVariables = $matches[2] ?? '[]';
-            $includeVariables = $this->arrayStringToArrayConverter->convert($includeVariables);
+            $includeVariables = $this->convertComponentData($includeVariables, $view);
             // Filter out attributes
             $includeVariables = array_filter($includeVariables, function (string|int $key): bool {
                 return is_string($key) && preg_match('#^[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$#s', $key) === 1;

--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -57,7 +57,7 @@ final class BladeToPHPCompiler
      * @see https://regex101.com/r/B3BbxW/1
      * @var string
      */
-    private const BACKED_COMPONENT_REGEX = '/if \(isset\(\$component\)\).+?\$component = (.*?)::resolve\((\[(?:.*?)?\]) .+?\$component->withAttributes\(\[.*?\]\);/s';
+    private const BACKED_COMPONENT_REGEX = '/if \(isset\(\$component\)\).+?\$component = (.*?)::resolve\((\[(?:.*?)?\]) \+ \(isset\(\$attributes\).+?\$component->withAttributes\(\[.*?\]\);/s';
 
     /**
      * @see https://regex101.com/r/mt3PUM/1

--- a/tests/Compiler/BladeToPHPCompiler/Fixture/backed-component-with-brackets.blade.php
+++ b/tests/Compiler/BladeToPHPCompiler/Fixture/backed-component-with-brackets.blade.php
@@ -1,0 +1,9 @@
+<x-backed-component :b="$b" panel-class="max-h-[80vh] flex flex-col"/>
+-----
+<?php
+
+/** @var Illuminate\Support\ViewErrorBag $errors */
+/** @var Illuminate\View\Factory $__env */
+/** @var Illuminate\Foundation\Application $app */
+/** file: foo.blade.php, line: 1 */
+$component = new App\View\Components\BackedComponent(b: $b, panelClass: 'max-h-[80vh] flex flex-col');

--- a/tests/skeleton/app/View/Components/BackedComponent.php
+++ b/tests/skeleton/app/View/Components/BackedComponent.php
@@ -11,6 +11,7 @@ class BackedComponent extends Component
 
     public function __construct(
         private readonly string $b,
+        private readonly string $panelClass = '',
     ) {
     }
 
@@ -20,6 +21,7 @@ class BackedComponent extends Component
             'a' => 'a',
             'b' => $this->b,
             'c' => $this->c,
+            'panelClass' => $this->panelClass,
         ]);
     }
 }


### PR DESCRIPTION
Analysing a template that renders a class-based component kills the whole PHPStan run when a constructor-prop value contains `]` followed by a space - for example a Tailwind arbitrary value with more classes after it:

```blade
<x-modal panel-class="max-h-[80vh] flex flex-col" />
```

`BACKED_COMPONENT_REGEX` captures the `::resolve([...])` data array lazily, right-anchored on `] `, so the capture stops inside the attribute value (`['panelClass' => 'max-h-[80vh]`). `ArrayStringToArrayConverter::convert()` then throws `PhpParser\Error: Syntax error, unexpected T_ENCAPSED_AND_WHITESPACE`, nothing catches it, and the run aborts with "result is incomplete because of severe errors" without naming the template. Only values that map to a constructor parameter reach the resolve array, which makes the trigger look random from the outside: `class="max-h-[80vh] ..."` is fine, while `panel-class="..."` on a component with a `$panelClass` param is not.

The first commit anchors the capture on ` + (isset($attributes)`, the suffix Laravel emits right after the data array - the same anchor `ANONYMOUS_COMPONENT_REGEX` already uses. The regression test fails with the parser fatal before the fix and passes after.

The second commit is separable: it catches the parser error at the two unguarded `convert()` call sites and reports a `bladestan.parsing` error naming the file, so a future capture miss degrades to an attributed finding instead of aborting the run unattributed. Happy to drop that one if you'd rather keep this to the regex fix.

One related spot I looked at but left alone: `ComponentAndVariables::preprocessTemplate()` matches `@props` with a similarly lazy `(\[.*?\])\)` group, so a default value containing `])` could truncate the same way. The parenthesis-balancing loop underneath partly covers it, so I didn't touch it here.
