### PR TITLE
Fix: getHash() crashes on PHPStan >= 2.2 because the container is not booted yet

### DIFF
--- a/src/PHPStan/BladeSignatureCacheMetaExtension.php
+++ b/src/PHPStan/BladeSignatureCacheMetaExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bladestan\PHPStan;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Contracts\View\Factory as ViewFactory;
 use Illuminate\View\FileViewFinder;
 use PHPStan\Analyser\ResultCache\ResultCacheMetaExtension;
@@ -23,11 +24,12 @@ final class BladeSignatureCacheMetaExtension implements ResultCacheMetaExtension
 
     public function getHash(): string
     {
-        $paths = $this->getViewPaths();
-
         try {
+            // PHPStan >= 2.2 calls getHash() before the bootstrapFiles run, so the
+            // Laravel container may not be booted yet and resolve() will fail.
+            $paths = $this->getViewPaths();
             $files = $this->discoverBladeFiles($paths);
-        } catch (UnexpectedValueException) {
+        } catch (UnexpectedValueException | BindingResolutionException) {
             // return a unique hash so the cache is conservatively invalidated.
             return hash('xxh128', microtime());
         }


### PR DESCRIPTION
Since PHPStan 2.2, `ResultCacheManager::getMetaFromPhpStanExtensions()` calls `ResultCacheMetaExtension::getHash()` *before* the configured `bootstrapFiles` are executed. `BladeSignatureCacheMetaExtension::getHash()` calls `getViewPaths()`, which does `resolve(ViewFactory::class)` on a Laravel container that has not been bootstrapped yet, so the whole analysis dies at startup:

```
Illuminate\Contracts\Container\BindingResolutionException
Target [Illuminate\Contracts\View\Factory] is not instantiable.
  src/PHPStan/BladeSignatureCacheMetaExtension.php:50  ->getViewPaths()
  src/PHPStan/BladeSignatureCacheMetaExtension.php:26  ->getHash()
  phpstan.phar/src/Analyser/ResultCache/ResultCacheManager.php:1868  ->getMetaFromPhpStanExtensions()
```

Reproduced by swapping only the `phpstan.phar` binary (2.1.54 → 2.2.13) on an otherwise identical tree: 2.1 runs, 2.2 crashes, in both directions.

`getHash()` already handles an unusable view tree by returning a unique hash so the result cache is conservatively invalidated. This applies the same treatment to the not-yet-booted container: move `getViewPaths()` inside the existing `try` and also catch `BindingResolutionException`. Analysis then runs with an invalidated cache for that execution, which is the correct behaviour when view paths cannot be determined. No behaviour change once the container *is* available.

The test suite passes on this branch (`composer test`): `Tests: 100, Assertions: 100, Risky: 1` — the single risky test, `PhpLineToTemplateLineResolverTest::test@File with no contents`, is pre-existing and unrelated.
