### PR TITLE
Stop compiling a template into itself on recursive includes

### DIFF
--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -86,6 +86,16 @@ final class BladeToPHPCompiler
     private array $errors;
 
     /**
+     * Template files currently being inlined, outermost first. A template that
+     * includes itself (a tree node rendering its children) or two templates that
+     * include each other would otherwise be inlined without end until the worker
+     * runs out of memory.
+     *
+     * @var list<string>
+     */
+    private array $inlineStack = [];
+
+    /**
      * @var array<string, Type>
      */
     private readonly array $shared;
@@ -136,6 +146,7 @@ final class BladeToPHPCompiler
         array $parametersArray
     ): PhpFileContentsWithLineMap {
         $this->errors = [];
+        $this->inlineStack = [];
 
         $variablesAndTypes = $this->getViewData($viewName)
             + $parametersArray;
@@ -265,12 +276,21 @@ final class BladeToPHPCompiler
                 $this->errors[] = [$exception->getMessage(), 'bladestan.missing'];
             }
 
+            // A recursive include: drop it from the compiled template instead of inlining the
+            // same template into itself again.
+            if ($includedFilePath !== '' && in_array($includedFilePath, $this->inlineStack, true)) {
+                $rawPhpContent = str_replace($inlinedElement->rawPhpContent, '', $rawPhpContent);
+                continue;
+            }
+            $this->inlineStack[] = $includedFilePath;
+
             $includedContent = $inlinedElement->preprocessTemplate($includedContent, array_keys($this->shared));
             $includedContent = $this->inlineInclude(
                 $includedFilePath,
                 $includedContent,
                 $inlinedElement->getInnerScopeVariableNames($allVariablesList)
             );
+            array_pop($this->inlineStack);
 
             $rawPhpContent = str_replace(
                 $inlinedElement->rawPhpContent,

--- a/src/TemplateCompiler/Rules/TemplateRulesRegistry.php
+++ b/src/TemplateCompiler/Rules/TemplateRulesRegistry.php
@@ -19,6 +19,8 @@ final class TemplateRulesRegistry implements Registry
     private const EXCLUDED_RULES = [
         'Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule',
         'Symplify\PHPStanRules\Rules\NoDynamicNameRule',
+        // Includes are already inlined when a compiled template is analysed.
+        'Bladestan\Rules\BladeRule',
     ];
 
     /**

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -60,6 +60,16 @@ final class BladeRuleTest extends RuleTestCase
             ['Undefined variable: $bar', 9],
         ]];
 
+        yield [__DIR__ . '/Fixture/file-including-itself.php', [
+            ['Binary operation "+" between string and 10 results in an error.', 9],
+        ]];
+
+        yield [__DIR__ . '/Fixture/file-including-itself-inline.php', [
+            ['Binary operation "+" between \'bar\' and 10 results in an error.', 9],
+            ['Binary operation "+" between string and 10 results in an error.', 9],
+            ['Empty array passed to foreach.', 9],
+        ]];
+
         yield [__DIR__ . '/Fixture/laravel-component-function.php', [
             ['Binary operation "+" between string and 10 results in an error.', 17],
         ]];

--- a/tests/Rules/Fixture/file-including-itself-inline.php
+++ b/tests/Rules/Fixture/file-including-itself-inline.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelViewFunction;
+
+use function view;
+
+view('file_including_itself_inline', [
+    'foo' => 'foo',
+    'children' => ['bar'],
+]);

--- a/tests/Rules/Fixture/file-including-itself.php
+++ b/tests/Rules/Fixture/file-including-itself.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelViewFunction;
+
+use function view;
+
+view('file_including_itself', [
+    'foo' => 'foo',
+    'children' => ['bar'],
+]);

--- a/tests/skeleton/resources/views/file_including_itself.blade.php
+++ b/tests/skeleton/resources/views/file_including_itself.blade.php
@@ -1,0 +1,8 @@
+{{ $foo + 10 }}
+
+@foreach ($children as $child)
+    @include('file_including_itself', [
+        'foo' => 'bar',
+        'children' => [],
+    ])
+@endforeach

--- a/tests/skeleton/resources/views/file_including_itself_inline.blade.php
+++ b/tests/skeleton/resources/views/file_including_itself_inline.blade.php
@@ -1,0 +1,5 @@
+{{ $foo + 10 }}
+
+@foreach ($children as $child)
+    @include('file_including_itself_inline', ['foo' => 'bar', 'children' => []])
+@endforeach


### PR DESCRIPTION
A template that includes itself - a tree node rendering its children - was inlined without end. Two mechanisms fed each other: the compiler inlines every include it finds with no recursion check, and the Blade rule is part of the rule set that analyses the compiled template, so a $__env->make() that survived inlining is compiled again from scratch, one level deeper each time. On a real project one worker passed 6 GB and PhpStan was killed (exit 137) before writing a single finding.

The compiler now keeps a stack of the templates being inlined and drops an include that is already on it.

The Blade rule is excluded from the template analyser's rule set. Includes and components are inlined into the compiled template before it is analysed, so the rule has nothing left to do inside one. Running it there re-enters the compiler on any $__env->make() that survived inlining - a recursive include, or one whose compiled text could not be replaced - with a fresh include stack, and that nesting only ends when the worker runs out of memory.

Two fixtures cover both paths. A one-line self-include is inlined once and then stopped, with the nested level still reporting its own findings. A multi-line self-include is not inlined at all today - the line-marker comments the pre-compiler injects into the data array keep the compiled text from matching what the collector pretty-prints - so it used to recurse through the rule alone; it now terminates with the root finding.

Generated with Claude