### PR TITLE
Let a project declare its own view-rendering classes as render sites

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -1,6 +1,11 @@
 parametersSchema:
     bladestan: structure([
         reportUnanalysedTemplates: bool()
+        renderSiteClasses: listOf(structure([
+            class: string()
+            viewNameArg: int()
+            dataArg: int()
+        ]))
     ])
 
 parameters:
@@ -10,6 +15,11 @@ parameters:
         # misconfiguration rather than a silent one. Set to false if you only
         # want view() call-site validation.
         reportUnanalysedTemplates: true
+
+        # Classes that wrap view() behind their own constructor. The template
+        # name is only a parameter inside such a class, so without naming it
+        # here every call site through it is invisible. Subclasses count.
+        renderSiteClasses: []
 
     bootstrapFiles:
         - ../bootstrap.php
@@ -117,6 +127,10 @@ services:
     - Bladestan\NodeAnalyzer\RenderSiteMatcher
     - Bladestan\NodeAnalyzer\LaravelViewFunctionMatcher
     - Bladestan\NodeAnalyzer\MailablesContentMatcher
+    -
+        class: Bladestan\NodeAnalyzer\ConfiguredRenderSiteMatcher
+        arguments:
+            renderSiteClasses: %bladestan.renderSiteClasses%
     - Bladestan\NodeAnalyzer\BladeViewMethodsMatcher
     - Bladestan\NodeAnalyzer\ViewDataParametersAnalyzer
     - Bladestan\NodeAnalyzer\ViewVariableAnalyzer

--- a/src/NodeAnalyzer/ConfiguredRenderSiteMatcher.php
+++ b/src/NodeAnalyzer/ConfiguredRenderSiteMatcher.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bladestan\NodeAnalyzer;
+
+use Bladestan\ValueObject\RenderTemplateWithParameters;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Type\ObjectType;
+use ValueError;
+
+/**
+ * Render sites the project declares itself: a class that wraps view() behind
+ * its own constructor.
+ *
+ * A project that renders through `new SomeViewResponse($name, $data)` hides the
+ * template name from the view() call inside, where it is only a parameter, so
+ * every such call site is invisible. Naming the class, and which constructor
+ * argument carries the name and the data, makes it a render site like any
+ * other.
+ *
+ * Subclasses count: a PDF variant extending the base response renders the same
+ * way.
+ */
+final class ConfiguredRenderSiteMatcher
+{
+    /**
+     * @param list<array{class: string, viewNameArg: int, dataArg: int}> $renderSiteClasses
+     */
+    public function __construct(
+        private readonly ViewDataParametersAnalyzer $viewDataParametersAnalyzer,
+        private readonly array $renderSiteClasses,
+    ) {
+    }
+
+    /**
+     * @return list<RenderTemplateWithParameters>
+     *
+     * @throws ValueError
+     */
+    public function match(New_ $new, Scope $scope): array
+    {
+        if (! $new->class instanceof Name) {
+            return [];
+        }
+
+        $instantiated = new ObjectType((string) $new->class);
+        foreach ($this->renderSiteClasses as $renderSite) {
+            if (! (new ObjectType($renderSite['class']))->isSuperTypeOf($instantiated)->yes()) {
+                continue;
+            }
+
+            $template = $this->matchOne($new, $scope, $renderSite['viewNameArg'], $renderSite['dataArg']);
+            if ($template instanceof RenderTemplateWithParameters) {
+                return [$template];
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @throws ValueError
+     */
+    private function matchOne(New_ $new, Scope $scope, int $viewNameArg, int $dataArg): ?RenderTemplateWithParameters
+    {
+        $arguments = $new->getArgs();
+        $viewName = $arguments[$viewNameArg] ?? null;
+        if ($viewName === null || ! $viewName->value instanceof String_) {
+            return null;
+        }
+
+        $parameters = [];
+        $hasUnresolvedData = false;
+        $data = $arguments[$dataArg] ?? null;
+        if ($data !== null) {
+            $resolved = $this->viewDataParametersAnalyzer->resolveParametersArray($data, $scope);
+            $parameters = $resolved->parameters;
+            $hasUnresolvedData = ! $resolved->resolved;
+        }
+
+        return new RenderTemplateWithParameters($viewName->value->value, $parameters, false, $hasUnresolvedData);
+    }
+}

--- a/src/NodeAnalyzer/RenderSiteMatcher.php
+++ b/src/NodeAnalyzer/RenderSiteMatcher.php
@@ -29,6 +29,7 @@ final class RenderSiteMatcher
         private readonly LaravelViewFunctionMatcher $laravelViewFunctionMatcher,
         private readonly BladeViewMethodsMatcher $bladeViewMethodsMatcher,
         private readonly MailablesContentMatcher $mailablesContentMatcher,
+        private readonly ConfiguredRenderSiteMatcher $configuredRenderSiteMatcher,
     ) {
     }
 
@@ -43,7 +44,10 @@ final class RenderSiteMatcher
             $node instanceof StaticCall,
             $node instanceof FuncCall => $this->laravelViewFunctionMatcher->match($node, $scope),
             $node instanceof MethodCall => $this->bladeViewMethodsMatcher->match($node, $scope),
-            $node instanceof New_ => $this->mailablesContentMatcher->match($node, $scope),
+            $node instanceof New_ => [
+                ...$this->mailablesContentMatcher->match($node, $scope),
+                ...$this->configuredRenderSiteMatcher->match($node, $scope),
+            ],
             default => [],
         };
     }

--- a/tests/Rules/Fixture/render-site-class-correct.php
+++ b/tests/Rules/Fixture/render-site-class-correct.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RenderSiteClassCorrect;
+
+use Bladestan\Tests\Rules\Source\SomeViewResponse;
+
+new SomeViewResponse('signed-template', [
+    'title' => 'Hello World',
+    'user' => new \App\Models\User(),
+]);

--- a/tests/Rules/Fixture/render-site-class-subclass.php
+++ b/tests/Rules/Fixture/render-site-class-subclass.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RenderSiteClassSubclass;
+
+use Bladestan\Tests\Rules\Source\SomePdfViewResponse;
+
+new SomePdfViewResponse('signed-template', [
+    'title' => 1,
+    'user' => new \App\Models\User(),
+]);

--- a/tests/Rules/Fixture/render-site-class-wrong-type.php
+++ b/tests/Rules/Fixture/render-site-class-wrong-type.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace RenderSiteClassWrongType;
+
+use Bladestan\Tests\Rules\Source\SomeViewResponse;
+
+new SomeViewResponse('signed-template', [
+    'title' => 1,
+    'user' => new \App\Models\User(),
+]);

--- a/tests/Rules/RenderSiteClassesRuleTest.php
+++ b/tests/Rules/RenderSiteClassesRuleTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bladestan\Tests\Rules;
+
+use Bladestan\Rules\ViewCallSiteRule;
+use Iterator;
+use PHPStan\Rules\Rule;
+use PHPStan\Testing\RuleTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * A project that renders through its own wrapper class - `new ViewResponse($name, $data)` -
+ * hides the template name from the `view()` call inside it, where it is only a parameter.
+ * Declaring the class in `renderSiteClasses` makes each `new` a render site, so the call
+ * site is validated against the template's signature like any other.
+ *
+ * @extends RuleTestCase<ViewCallSiteRule>
+ */
+final class RenderSiteClassesRuleTest extends RuleTestCase
+{
+    /**
+     * @param list<array{0: string, 1: int, 2?: string|null}> $expectedErrorsWithLines
+     */
+    #[DataProvider('provideData')]
+    public function testRule(string $analysedFile, array $expectedErrorsWithLines): void
+    {
+        $this->analyse([$analysedFile], $expectedErrorsWithLines);
+    }
+
+    public static function provideData(): Iterator
+    {
+        // The declared class is matched, and its data argument is checked
+        // against the signature.
+        yield [__DIR__ . '/Fixture/render-site-class-wrong-type.php', [
+            ['Template signed-template expects parameter $title of type string, but int given.', 9],
+        ]];
+
+        // A subclass renders the same way, so declaring the base covers it.
+        yield [__DIR__ . '/Fixture/render-site-class-subclass.php', [
+            ['Template signed-template expects parameter $title of type string, but int given.', 9],
+        ]];
+
+        // Matching types pass, the same as a plain view() call.
+        yield [__DIR__ . '/Fixture/render-site-class-correct.php', []];
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [__DIR__ . '/config/render_site_classes.neon'];
+    }
+
+    protected function getRule(): Rule
+    {
+        return self::getContainer()->getByType(ViewCallSiteRule::class);
+    }
+}

--- a/tests/Rules/Source/SomePdfViewResponse.php
+++ b/tests/Rules/Source/SomePdfViewResponse.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bladestan\Tests\Rules\Source;
+
+/**
+ * A subclass renders the same way, so declaring the base class covers it.
+ */
+final class SomePdfViewResponse extends SomeViewResponse
+{
+}

--- a/tests/Rules/Source/SomeViewResponse.php
+++ b/tests/Rules/Source/SomeViewResponse.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Bladestan\Tests\Rules\Source;
+
+/**
+ * A project's own response class that renders a view from its constructor, the
+ * shape `renderSiteClasses` exists for.
+ */
+class SomeViewResponse
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        public readonly string $viewName,
+        public readonly array $data = [],
+    ) {
+    }
+}

--- a/tests/Rules/config/render_site_classes.neon
+++ b/tests/Rules/config/render_site_classes.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../config/extension.neon
+
+parameters:
+    bladestan:
+        renderSiteClasses:
+            -
+                class: Bladestan\Tests\Rules\Source\SomeViewResponse
+                viewNameArg: 0
+                dataArg: 1


### PR DESCRIPTION
A project that renders through a wrapper - `new ViewResponse($name, $data)` - hides the template name from the view() call inside it, where it is only a parameter. RenderSiteMatcher then matches nothing, and every template reached that way is invisible: no signature is generated for it, and its call sites are never validated. In the codebase this came from that is 209 call sites across 92 files, and about half the templates that had no signature.

`renderSiteClasses` names such a class and says which constructor argument carries the view name and which carries the data:

    parameters:
        bladestan:
            renderSiteClasses:
                -
                    class: App\Http\Response\ViewResponse
                    viewNameArg: 0
                    dataArg: 1

Subclasses are matched too, via ObjectType::isSuperTypeOf rather than a class name comparison, because a PDF variant extending the base response renders the same way.

The matcher is the same shape as MailablesContentMatcher - resolve the view name from a String_ argument, resolve the data with ViewDataParametersAnalyzer, return RenderTemplateWithParameters - so both the call-site rule and the signature generator pick it up through the single RenderSiteMatcher entry point. Defaults to an empty list, so nothing changes for a project that does not set it.